### PR TITLE
Screenreader issue on header buttons fixed

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -149,9 +149,10 @@ export default function Header() {
                 className: menuButton,
                 style: { color },
                 component: RouterLink,
+                'aria-label': label,
               }}
             >
-              {label}
+              <span aria-hidden="true">{label}</span>
             </Button>
           );
         });


### PR DESCRIPTION
- Screen reader now reads "Join Us" instead of "Join U.S."