### PR TITLE
Login Auth Error

### DIFF
--- a/src/components/AccountForms/LoginForm/LoginForms.test.js
+++ b/src/components/AccountForms/LoginForm/LoginForms.test.js
@@ -51,7 +51,7 @@ describe('<LoginForm />', () => {
 
       const authError = screen.queryByRole('alert');
       const emailInputError = screen.queryByText('Invalid email format');
-      const passwordInputError = screen.queryByText('Enter a password');
+      const passwordInputError = screen.queryByText('Password is required');
 
       expect(authError).toBeNull();
       expect(emailInputError).toBeNull();
@@ -74,7 +74,7 @@ describe('<LoginForm />', () => {
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
-    test('authError and email error should show', async () => {
+    test('email error should show', async () => {
       const emailInput = screen.getByRole('textbox', { name: /email/i });
       const passwordInput = screen.getByTestId('password');
       const submitButton = screen.getByRole('button', { name: /SIGN IN/i });
@@ -85,11 +85,9 @@ describe('<LoginForm />', () => {
         userEvent.click(submitButton);
       });
 
-      const authError = screen.queryByRole('alert');
       const emailInputError = screen.queryByText('Invalid email format');
-      const passwordInputError = screen.queryByText('Enter a password');
+      const passwordInputError = screen.queryByText('Password is required');
 
-      expect(authError).not.toBeNull();
       expect(emailInputError).not.toBeNull();
       expect(passwordInputError).toBeNull();
     });
@@ -109,26 +107,6 @@ describe('<LoginForm />', () => {
 
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
-
-    test('authError and password error should show', async () => {
-      const emailInput = screen.getByRole('textbox', { name: /email/i });
-      const passwordInput = screen.getByTestId('password');
-      const submitButton = screen.getByRole('button', { name: /SIGN IN/i });
-
-      await act(async () => {
-        userEvent.type(emailInput, 'testing@gmail.com');
-        userEvent.type(passwordInput, '');
-        userEvent.click(submitButton);
-      });
-
-      const authError = screen.queryByRole('alert');
-      const emailInputError = screen.queryByText('Invalid email format');
-      const passwordInputError = screen.queryByText('Enter a password');
-
-      expect(authError).not.toBeNull();
-      expect(emailInputError).toBeNull();
-      expect(passwordInputError).not.toBeNull();
-    });
   });
 
   describe('with invalid email and password', () => {
@@ -146,7 +124,7 @@ describe('<LoginForm />', () => {
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
-    test('authError and both email/password error should show', async () => {
+    test('both email/password error should show', async () => {
       const emailInput = screen.getByRole('textbox', { name: /email/i });
       const passwordInput = screen.getByTestId('password');
       const submitButton = screen.getByRole('button', { name: /SIGN IN/i });
@@ -157,11 +135,9 @@ describe('<LoginForm />', () => {
         userEvent.click(submitButton);
       });
 
-      const authError = screen.queryByRole('alert');
       const emailInputError = screen.queryByText('Invalid email format');
-      const passwordInputError = screen.queryByText('Enter a password');
+      const passwordInputError = screen.queryByText('Password is required');
 
-      expect(authError).not.toBeNull();
       expect(emailInputError).not.toBeNull();
       expect(passwordInputError).not.toBeNull();
     });

--- a/src/components/AccountForms/LoginForm/index.js
+++ b/src/components/AccountForms/LoginForm/index.js
@@ -166,7 +166,7 @@ const LoginForm = ({ testOnSubmit }) => {
             <Button
               type="submit"
               className={`${classes.button} ${classes.signIn}`}
-              onClick={clearErrors}
+              onClick={() => clearErrors('server')}
             >
               SIGN IN
             </Button>

--- a/src/components/AccountForms/LoginForm/index.js
+++ b/src/components/AccountForms/LoginForm/index.js
@@ -35,7 +35,7 @@ const passwordRequirements = {
 
 const LoginForm = ({ testOnSubmit }) => {
   const [showPassword, setShowPassword] = useState(false);
-  const { register, handleSubmit, errors, setError } = useForm();
+  const { register, handleSubmit, errors, setError, clearErrors } = useForm();
   const {
     globalState: { isMobile },
   } = useContext(GlobalContext);
@@ -53,15 +53,15 @@ const LoginForm = ({ testOnSubmit }) => {
   } = useAuth();
 
   const onSubmit = (credentials) => {
-    const inProduction = process.env.NODE_ENV === 'production';
-    const options = {
-      category: 'onSubmit',
-      action: 'Logged In',
-    };
     request
       .post(API_PATH.LOGIN, credentials)
       .then(({ status }) => {
         if (status === 200) {
+          const inProduction = process.env.NODE_ENV === 'production';
+          const options = {
+            category: 'onSubmit',
+            action: 'Logged In',
+          };
           inProduction && event(options);
           dispatch(updateAuth(auth.checkCookie()));
           history.push('/mentors');
@@ -93,7 +93,7 @@ const LoginForm = ({ testOnSubmit }) => {
           {errors.server && (
             <div className={`${classes.alert} ${classes.error}`}>
               <Error />
-              <p role="alert">Sorry, invalid email or password. Try again?</p>
+              <p role="alert">{errors.server.message}</p>
             </div>
           )}
           {isEmpty(errors) && timedOut && (
@@ -166,6 +166,7 @@ const LoginForm = ({ testOnSubmit }) => {
             <Button
               type="submit"
               className={`${classes.button} ${classes.signIn}`}
+              onClick={clearErrors}
             >
               SIGN IN
             </Button>


### PR DESCRIPTION
This is assuming the unauthorized response `api/server/routes/login/index.js` will look something like this:
```js
res
  .status(HttpStatusCodes.StatusCodes.UNAUTHORIZED)
  .send({
    status: 401,
    error: 'Unauthorized message here'
  })
  .end();
```

The auth error message is still hard-coded for now. Maybe we can have the server set the message instead? 

**Empty inputs**
<img width="981" alt="Screen Shot 2020-12-16 at 3 51 38 PM" src="https://user-images.githubusercontent.com/53205189/102405387-12171600-3fb7-11eb-9e49-10f76f63e9ff.png">

**401**
<img width="981" alt="Screen Shot 2020-12-16 at 3 51 08 PM" src="https://user-images.githubusercontent.com/53205189/102405388-12afac80-3fb7-11eb-9503-0fb18f136e06.png">

