### PR TITLE
refactored logic to catch login error

### DIFF
--- a/src/components/AccountForms/LoginForm/index.js
+++ b/src/components/AccountForms/LoginForm/index.js
@@ -52,29 +52,25 @@ const LoginForm = ({ testOnSubmit }) => {
     authState: { isLoggedIn },
   } = useAuth();
 
-  const onSubmit = (credentials) => {
-    request
-      .post(API_PATH.LOGIN, credentials)
-      .then(({ status }) => {
-        if (status === 200) {
-          const inProduction = process.env.NODE_ENV === 'production';
-          const options = {
-            category: 'onSubmit',
-            action: 'Logged In',
-          };
-          inProduction && event(options);
-          dispatch(updateAuth(auth.checkCookie()));
-          history.push('/mentors');
-        }
-      })
-      .catch(({ status, data: { error } }) => {
-        if (status === 401 || status === 403) {
-          setError('server', {
-            type: 'auth',
-            message: error,
-          });
-        }
-      });
+  const onSubmit = async (credentials) => {
+    try {
+      await request.post(API_PATH.LOGIN, credentials);
+      const inProduction = process.env.NODE_ENV === 'production';
+      const options = {
+        category: 'onSubmit',
+        action: 'Logged In',
+      };
+      inProduction && event(options);
+      dispatch(updateAuth(auth.checkCookie()));
+      history.push('/mentors');
+    } catch ({ status, data: { error } }) {
+      if (status === 401 || status === 403) {
+        setError('server', {
+          type: 'auth',
+          message: error,
+        });
+      }
+    }
   };
 
   const handleClickShowPassword = () => {
@@ -148,7 +144,7 @@ const LoginForm = ({ testOnSubmit }) => {
                           onClick: handleClickShowPassword,
                         }}
                       >
-                        {showPassword ? <Visibility /> : <VisibilityOff />}
+                        {showPassword ? <VisibilityOff /> : <Visibility />}
                       </IconButton>
                     </InputAdornment>
                   ),

--- a/src/components/AccountForms/LoginForm/index.js
+++ b/src/components/AccountForms/LoginForm/index.js
@@ -63,11 +63,11 @@ const LoginForm = ({ testOnSubmit }) => {
       inProduction && event(options);
       dispatch(updateAuth(auth.checkCookie()));
       history.push('/mentors');
-    } catch ({ status, data: { error } }) {
+    } catch ({ status, data: { err } }) {
       if (status === 401 || status === 403) {
         setError('server', {
           type: 'auth',
-          message: error,
+          message: err,
         });
       }
     }

--- a/src/components/AccountForms/LoginForm/index.js
+++ b/src/components/AccountForms/LoginForm/index.js
@@ -67,7 +67,7 @@ const LoginForm = ({ testOnSubmit }) => {
           history.push('/mentors');
         }
       })
-      .catch(({ status, error }) => {
+      .catch(({ status, data: { error } }) => {
         if (status === 401 || status === 403) {
           setError('server', {
             type: 'auth',

--- a/src/utils/axiosConfig.js
+++ b/src/utils/axiosConfig.js
@@ -18,7 +18,7 @@ const request = axios.create({
 */
 request.interceptors.response.use(
   (response) => response,
-  (error) => Promise.reject(error.response.data)
+  (error) => Promise.reject(error.response)
 );
 
 export default request;


### PR DESCRIPTION
### Changes:
updated logic to catch login error

api response should be something like below on auth error:

`res.status(HttpStatusCodes.StatusCodes.UNAUTHORIZED).send({
    error: 'Unauthorized message here',
  });`